### PR TITLE
Allow building with zig 0.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for easily generating Av1an commands for AV1 encoding. Written in Zig.
 
 ## Description
 
-This program generates an AV1 video encoding command for use with [Av1an](https://github.com/master-of-zen/Av1an), a chunked AV1 encoding tool for use with [aomenc](https://aomedia.googlesource.com/aom/), [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1/), and [rav1e](https://github.com/xiph/rav1e). 
+This program generates an AV1 video encoding command for use with [Av1an](https://github.com/master-of-zen/Av1an), a chunked AV1 encoding tool for use with [aomenc](https://aomedia.googlesource.com/aom/), [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1/), and [rav1e](https://github.com/xiph/rav1e).
 
 This tool takes in the video resolution, frame rate, desired encoder, speed preset, and target bitrate range as command line arguments. Based on these parameters, it calculates settings like tile columns/rows, lag-in-frames, CRF, and encoder speed preset. Then, it injects these into a generated encoding command string.
 
@@ -13,14 +13,14 @@ The output is a full `av1an` command that can be run to encode a video based on 
 ## Usage
 
 ```bash
-av1an-command-gen [width] [height] [fps] [encoder] [speed] [bitrate_target]
+./av1an-command-gen [width] [height] [fps] [encoder] [speed] [bitrate_target]
 ```
 
-- `width` - Input video width in pixels 
+- `width` - Input video width in pixels
 - `height` - Input video height in pixels
 - `fps` - Input video frame rate
 - `encoder` - `aom`, `svt`, or `rav1e`
-- `speed` - `slower`, `slow`, `med`, `fast`, `faster` 
+- `speed` - `slower`, `slow`, `med`, `fast`, `faster`
 - `bitrate_target` - `lowest`, `low`, `med`, `high`
 
 ## Examples
@@ -28,18 +28,18 @@ av1an-command-gen [width] [height] [fps] [encoder] [speed] [bitrate_target]
 Generate a command for encoding a 1280x720 video at 24 fps using rav1e at 'med' speed and 'low' bitrate target:
 
 ```bash
-av1an-command-gen 1280 720 24 rav1e med low
+./av1an-command-gen 1280 720 24 rav1e med low
 ```
 
 Generate a command for encoding a 1920x1080 video at 30 fps using svt-av1 at 'fast' speed and 'high' bitrate target:
 
 ```bash
-av1an-command-gen 1920 1080 30 svt fast high
+./av1an-command-gen 1920 1080 30 svt fast high
 ```
 
 ## Building
 
-This program requires the [Zig](https://ziglang.org/) v0.11.0 programming language. 
+This program requires [Zig](https://ziglang.org/) version 0.12.0 or higher.
 
 To build:
 

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .name = "av1an-command-gen",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) void {
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
     .name = "av1an-command-gen",
-    .version = "0.0.1",
+    .version = "0.0.2",
     .paths = .{""},
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -277,19 +277,19 @@ fn printHelp() !void {
         \\Generates an AV1 encoding command for live-action encoding with Av1an
         \\
         \\Usage:
-        \\	av1an-command-gen [width] [height] [fps] [encoder] [speed] [size]
+        \\  av1an-command-gen [width] [height] [fps] [encoder] [speed] [size]
         \\
         \\Options:
-        \\    	Width:		Your input width in pixels
-        \\    	Height:		Your input height in pixels
-        \\    	fps:		Your input frames per second
-        \\    	Encoder:	Accepts `aom`, `svt`, `rav1e`
-        \\    	Speed:		Accepts `slower`, `slow`, `med`, `fast`, `faster`
-        \\    	Size:		Accepts `lowest`, `low`, `med`, `high`
+        \\  Width:         Your input width in pixels
+        \\  Height:        Your input height in pixels
+        \\  fps:           Your input frames per second
+        \\  Encoder:       Accepts `aom`, `svt`, `rav1e`
+        \\  Speed:         Accepts `slower`, `slow`, `med`, `fast`, `faster`
+        \\  Size:          Accepts `lowest`, `low`, `med`, `high`
         \\
         \\Info:
-        \\    	--help, -h	Prints this help menu
-        \\    	--version, -v	Prints version information
+        \\  --help, -h     Prints this help menu
+        \\  --version, -v  Prints version information
         \\
     ;
 


### PR DESCRIPTION
Allows building with Zig versions >= 0.12.  
Most package managers currently host version 0.13: <https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager>

- 0.12 introduced changes to how the path is handled: <https://ziggit.dev/t/migration-guide-from-0-11-0-to-0-12-0/4281>
- In 0.14 (nightly) it ran into an issue during building that apparently has been caused by tab characters in the `--help` message.

Let me know if there are any issues with this, I've never used Zig before today.